### PR TITLE
Use application/json as Content-Type for requests sent to the hook

### DIFF
--- a/cmd/alert-gateway/common/structure.go
+++ b/cmd/alert-gateway/common/structure.go
@@ -119,6 +119,12 @@ type ValidUserGroup struct {
 	DutyGroup string
 }
 
+func GenerateJsonHeader() map[string]string {
+	return map[string]string {
+		"Content-Type": "application/json",
+	}
+}
+
 func HttpPost(url string, params map[string]string, headers map[string]string, body []byte) (*http.Response, error) {
 	//new request
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))

--- a/cmd/alert-gateway/initial/timer.go
+++ b/cmd/alert-gateway/initial/timer.go
@@ -166,7 +166,7 @@ func Send2Hook(content []common.Ready2Send, now string, t string, url string) {
 					To:     i.User,
 					Alerts: i.Alerts,
 				})
-			common.HttpPost(url, nil, nil, data)
+			common.HttpPost(url, nil, common.GenerateJsonHeader(), data)
 		}
 	} else {
 		for _, i := range content {
@@ -186,7 +186,7 @@ func Send2Hook(content []common.Ready2Send, now string, t string, url string) {
 					To:          i.User,
 					Alerts:      i.Alerts,
 				})
-			common.HttpPost(url, nil, nil, data)
+			common.HttpPost(url, nil, common.GenerateJsonHeader(), data)
 		}
 	}
 }


### PR DESCRIPTION
The default header used by Go http client is `application/octet-stream` which is a resonable choice according to the RFC spec.

Some framework cannot handle properly for json conversion, like `spring-boot`. Related dicussion can be found here https://github.com/spring-projects/spring-boot/issues/3313

Since we are sending json object, we can manually specify the header here for better compatibility.